### PR TITLE
Adding a refresh method for IGraphicLib

### DIFF
--- a/IGraphicLib.hpp
+++ b/IGraphicLib.hpp
@@ -41,7 +41,9 @@ namespace Arcade {
 		
 		// Clears the screen
 		virtual void clearWindow() = 0;
-
+		
+		// Displays the buffered frame to the screen
+		virtual void refreshWindow() = 0;
 		
 		/* Resources handling */
 		// Initializes the library


### PR DESCRIPTION
@lbrulet found that the IGraphicLib lacks a method for refreshing/hydrating the display with the buffered content (an equivalent of `refresh` in NCurses or `sfRenderWindow_display` in CSFML).
This PR proposes to add such a method.