### PR TITLE
Changed pollEvent to reflect on event availability

### DIFF
--- a/IGraphicLib.hpp
+++ b/IGraphicLib.hpp
@@ -89,7 +89,7 @@ namespace Arcade {
 		virtual Keys getLastEvent() = 0;
 		
 		// Saves the event in the Graphics library
-		virtual void pollEvent() = 0;
+		virtual bool pollEvent() = 0;
 		
 		// Deletes the last event
 		virtual void cleanEvent() = 0;


### PR DESCRIPTION
Proposal of Corentin Charriot.
Changing:
```C++
void pollEvent();
```
to 
```C++
bool pollEvent();
```
This would be helpful to know whether events are available or if there is none left to be processed.