### PR TITLE
Adding NONE to the Keys enum

### DIFF
--- a/Keys.hpp
+++ b/Keys.hpp
@@ -9,6 +9,7 @@
 
 namespace Arcade {
 	enum Keys {
+		NONE,
 		A, B, C, D, E, F, G, H, I, J, K, L, M,
 		N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
 		LEFT, RIGHT, UP, DOWN,


### PR DESCRIPTION
This change attempts to address the following scenario:
- I call `pollEvent()` to load past events and know if there were.
- I call `getLastEvent()` to get the last event that happened.

But then I don't know if there are events left to be processed or not.
Two solutions for this:
- Recall `pollEvent()` (and make it return true unless `getLastEvent()` has been called for every events)
- Add a None entry to the Keys enum that `getLastEvent()` can return when the event queue is emptied

This PR implements the second option, but we should choose which options we opt-in for.