### PR TITLE
Improved syntax for default constructor

### DIFF
--- a/IGraphicLib.hpp
+++ b/IGraphicLib.hpp
@@ -16,7 +16,7 @@
 namespace Arcade {
 	class IGraphicLib {
 	public:
-		IGraphicLib() {};
+		IGraphicLib() = default;
 		virtual ~IGraphicLib() = 0;
 
 		/* Get the name of the library */


### PR DESCRIPTION
I think this is pretty much self-explanatory.
The change itself is also straight-forward to understand.
