### PR TITLE
Removed references

### DIFF
--- a/IGameLib.hpp
+++ b/IGameLib.hpp
@@ -15,7 +15,7 @@ namespace Arcade {
 		virtual ~IGameLib() = default;
 
 		/* Get the name of the game */
-		virtual const std::string &getName() const = 0;
+		virtual const std::string getName() const = 0;
 
 
 		/* Resources handling */

--- a/IGraphicLib.hpp
+++ b/IGraphicLib.hpp
@@ -19,7 +19,7 @@ namespace Arcade {
 		virtual ~IGraphicLib() = 0;
 
 		/* Get the name of the library */
-		virtual const std::string &getName() const = 0;
+		virtual const std::string getName() const = 0;
 
 		/* Module info: Used to optimize initialization */
 		virtual bool supportSprite() const = 0;


### PR DESCRIPTION
This PR reverts references that were introduced in #23.
This made the following code impossible:
```C++
const std::string &SFMLGraphicLib::getName() const
{
    return "SFML";
}
```
