### PR TITLE
Adding color filling upon construction of PixelBox

### DIFF
--- a/PixelBox.hpp
+++ b/PixelBox.hpp
@@ -16,7 +16,8 @@ namespace Arcade {
 	class PixelBox {
 	public:
 		PixelBox(Vect<size_t> size = Vect<size_t>(),
-			Vect<size_t> pos = Vect<size_t>());
+			Vect<size_t> pos = Vect<size_t>(),
+			Color col = Color(255, 255, 255, 255));
 		~PixelBox() = default;
 
 		size_t getHeight() const;


### PR DESCRIPTION
We spoked about this with @lbrulet.
This PR add PixelBox pre-filling upon its construction.

I'm thinking maybe we could also add the following method too but maybe it's too much:
```C++
void Arcade::PixelBox::putRect(Vect<size_t> size, Vect<size_t> pos, Color col);
```
