### PR TITLE
Adding a cast override from Arcade::Color to unsigned char *

### DIFF
--- a/Color.hpp
+++ b/Color.hpp
@@ -22,6 +22,7 @@ namespace Arcade {
 		void setGreen(unsigned char green);
 		void setBlue(unsigned char blue);
 		void setAlpha(unsigned char alpha);
+		operator unsigned char *();
 
 	private:
 		unsigned char _red;


### PR DESCRIPTION
This PR makes the following code possible:
```C++
Arcade::Color c(255, 120, 142, 3);
unsigned char *arr = c;

printf("%hhu, %hhu, %hhu, %hhu\n", arr[0], arr[1], arr[2], arr[3]);
```

Correctly implemented, this outputs:
![image](https://user-images.githubusercontent.com/4294633/37865301-10f2280e-2f7b-11e8-82dd-8bdf3d39a156.png)

