### PR TITLE
Adding PixelBox::putRect() method

### DIFF
--- a/PixelBox.hpp
+++ b/PixelBox.hpp
@@ -38,6 +38,8 @@ namespace Arcade {
 		void putPixel(Vect<size_t> pos, Color col);
 		Color getPixel(Vect<size_t> pos) const;
 
+		void putRect(Vect<size_t> pos, Vect<size_t> size, Color col);
+
 		std::vector<Color> &getPixelArray();
 
 	private:


### PR DESCRIPTION
This PR adds the following method to the PixelBox class:
```C++
void Arcade::PixelBox::putRect(Vect<size_t> pos, Vect<size_t> size, Color col);
```
