### PR TITLE
Adding PixelBox::putCircle() and PixelBox::putDisk() methods

### DIFF
--- a/PixelBox.hpp
+++ b/PixelBox.hpp
@@ -39,6 +39,8 @@ namespace Arcade {
 		Color getPixel(Vect<size_t> pos) const;
 
 		void putRect(Vect<size_t> pos, Vect<size_t> size, Color col);
+		void putCircle(Vect<size_t> pos, size_t rad, Color col);
+		void putDisk(Vect<size_t> pos, size_t rad, Color col);
 
 		std::vector<Color> &getPixelArray();
 


### PR DESCRIPTION
This PR proposes to add the following two methods:
```C++
void Arcade::PixelBox::putCircle(Arcade::Vect<size_t> pos, size_t rad, Arcade::Color col);
void Arcade::PixelBox::putDisk(Arcade::Vect<size_t> pos, size_t rad, Arcade::Color col);
```
`Arcade::PixelBox::putCircle` draws a circle (only colors the outline).
`Arcade::PixelBox::putDisk` draws a filled circle (known as a disk).

Are these to much to ask for or are they acceptable ?