### PR TITLE
Fix norm issue in TextBox constructor

### DIFF
--- a/TextBox.hpp
+++ b/TextBox.hpp
@@ -16,8 +16,9 @@ namespace Arcade {
 	public:
 		TextBox(std::string const &text, Vect<size_t> pos,
 			size_t fontSize = 30,
-			Color color = Color(255, 255, 255, 255),
-			Color backgroundColor = Color(0, 0, 0, 255));
+			Vect<Color> colors = Vect<Color>(
+				Color(255, 255, 255, 255),
+				Color(0, 0, 0, 255)));
 		~TextBox() = default;
 
 		const std::string &getValue() const;

--- a/TextBox.hpp
+++ b/TextBox.hpp
@@ -15,10 +15,7 @@ namespace Arcade {
 	class TextBox {
 	public:
 		TextBox(std::string const &text, Vect<size_t> pos,
-			size_t fontSize = 30,
-			Vect<Color> colors = Vect<Color>(
-				Color(255, 255, 255, 255),
-				Color(0, 0, 0, 255)));
+			size_t fontSize = 30);
 		~TextBox() = default;
 
 		const std::string &getValue() const;


### PR DESCRIPTION
This PR fixes a norm issue mentioned in issue #49.
it reduces from 5 arguments to 4 by making use of a templated Vect instead of passing separate components.