### PR TITLE
[~] Return type for getMaxY / getMaxX

### DIFF
--- a/IGraphicLib.hpp
+++ b/IGraphicLib.hpp
@@ -66,9 +66,9 @@ namespace Arcade {
 		virtual Vect<size_t> getScreenSize() const = 0;
 
 		// get the Y max of the windows
-		virtual int getMaxY() const = 0;
+		virtual size_t getMaxY() const = 0;
 
 		// get the X max of the windows
-		virtual int getMaxX() const = 0;
+		virtual size_t getMaxX() const = 0;
 	};
 };


### PR DESCRIPTION
Because it makes no sense to return an int while getScreenSize return a size_t