### PR TITLE
Adding Arcade::Color::operator==

### DIFF
--- a/Color.hpp
+++ b/Color.hpp
@@ -23,6 +23,7 @@ namespace Arcade {
 		void setBlue(unsigned char blue);
 		void setAlpha(unsigned char alpha);
 		operator unsigned char *();
+		bool operator==(const Arcade::Color &other) const;
 
 	private:
 		unsigned char _red;


### PR DESCRIPTION
This allows Arcade::Color to be stored in vectors and other STL containers.

It would be implemented like this:
```C++
bool Arcade::Color::operator==(const Arcade::Color &other) const
{
	return _red == other._red && _green == other._green &&
		_blue == other._blue && _alpha == other._alpha;
}
```